### PR TITLE
Edm.Byte example was FF, is now 255

### DIFF
--- a/pages/documentation/overview.html
+++ b/pages/documentation/overview.html
@@ -196,8 +196,8 @@ Represents the mathematical concept of binary-valued logic</td>
 <tr>
 <td><strong>Edm.Byte</strong><br />
 Unsigned 8-bit integer value</td>
-<td>[A-Fa-f0-9]+</td>
-<td>Example 1: FF</td>
+<td>[0-9]+</td>
+<td>Example 1: 255</td>
 </tr>
 <tr>
 <td><strong>Edm.DateTime</strong><br />


### PR DESCRIPTION
V2 overview page wrongly stated that Edm.Byte uses hex values. In fact they are decimal values just as for the other integer Edm types.