### PR TITLE
Updated `Edm.Time` for [MS-ODATA] Revision 18.0

### DIFF
--- a/pages/documentation/overview.html
+++ b/pages/documentation/overview.html
@@ -4,7 +4,7 @@ title: Overview (OData Version 2.0)
 date: 2014-02-28 03:27:38.000000000 +08:00
 permalink: /documentation/odata-version-2-0/overview/
 ---
-<h5 class="alert alert-success">OData Version 4.0 is the current recommended version of OData. OData V4 has been standardized by OASIS and has many features not included in OData Version 2.0. 
+<h5 class="alert alert-success">OData Version 4.0 is the current recommended version of OData. OData V4 has been standardized by OASIS and has many features not included in OData Version 2.0.
 <br><br>
 <a href="/documentation/" class="alert-link" title=""><span class="glyphicon glyphicon-arrow-right"></span> Go to OData Version 4.0</a></h5>
 <p>The Open Data Protocol (OData) enables the creation of HTTP-based data services, which allow resources identified using Uniform Resource Identifiers (URIs) and defined in an abstract data model, to be published and edited by Web clients using simple HTTP messages. OData is intended to be used to expose and access information from a variety of sources including, but not limited to, relational databases, file systems, content management systems, and traditional Web sites.</p>
@@ -263,7 +263,7 @@ Represents fixed- or variable-length character data</td>
 <tr>
 <td><strong>Edm.Time</strong><br />
 Represents the time of day with values ranging from 0:00:00.x to 23:59:59.y, where x and y depend upon the precision</td>
-<td>time'&lt;timeLiteral&gt;' timeLiteral = Defined by the lexical representation for time at <a href="http://www.w3.org/TR/xmlschema-2">http://www.w3.org/TR/xmlschema-2</a></td>
+<td>time'&lt;timeLiteral&gt;' timeLiteral = Defined by the lexical representation for duration at <a href="http://www.w3.org/TR/xmlschema-2">http://www.w3.org/TR/xmlschema-2/#duration</a></td>
 <td>Example 1: 13:20:00</td>
 </tr>
 <tr>

--- a/pages/documentation/overview.html
+++ b/pages/documentation/overview.html
@@ -263,7 +263,7 @@ Represents fixed- or variable-length character data</td>
 <tr>
 <td><strong>Edm.Time</strong><br />
 Represents the time of day with values ranging from 0:00:00.x to 23:59:59.y, where x and y depend upon the precision</td>
-<td>time'&lt;timeLiteral&gt;' timeLiteral = Defined by the lexical representation for duration at <a href="http://www.w3.org/TR/xmlschema-2">http://www.w3.org/TR/xmlschema-2/#duration</a></td>
+<td>time'&lt;timeLiteral&gt;' timeLiteral = Defined by the lexical representation for dayTimeDuration in <a href="http://www.w3.org/TR/xmlschema11-2">http://www.w3.org/TR/xmlschema11-2/#dayTimeDuration</a></td>
 <td>Example 1: 13:20:00</td>
 </tr>
 <tr>


### PR DESCRIPTION
Updated `Edm.Time` for newest V2 Spec ([MS-ODATA] Revision “18.0”). 

```
[MS-ODATA] Revision "18.0" — v20151016 (page 33)
2.2.2 Abstract Type System

Edm.Time ->
timeUriLiteral =
   "time"
   SQUOTE
   timeLiteral
   SQUOTE
timeLiteral = <Defined by the lexical representation for dayTimeDuration in [XMLSCHEMA11/2:2012]>
```

Best Regards, Michael
